### PR TITLE
Made GVFS work

### DIFF
--- a/org.freecadweb.FreeCAD.yaml
+++ b/org.freecadweb.FreeCAD.yaml
@@ -14,6 +14,7 @@ finish-args:
   - --device=dri
   - --share=network
   - --filesystem=host # needed to make file saving work
+  - --filesystem=xdg-run/gvfs # make GnomeVFS accessible
 cleanup:
   - /include
   - /share/aclocal


### PR DESCRIPTION
By accessing `/run/user/$UID/gvfs/` FreeCAD can load and save files from GVFS mounts (network shares mounted using Nautilus)
See #22 