### PR TITLE
beta: update to 0.19_pre-22611

### DIFF
--- a/org.freecadweb.FreeCAD.yaml
+++ b/org.freecadweb.FreeCAD.yaml
@@ -505,9 +505,9 @@ modules:
       - type: git
         url: https://github.com/FreeCAD/FreeCAD.git
         # tag: 0.19_pre
-        # commit #22492 as built from master
-        commit: fe3f1b51b7be58367d08c5bb0f9f9d292671bb39
+        # commit #22611 as built from master
+        commit: 7f9c582996734b8d3f76e3b6ea243b4415fb5eb2
       - type: shell
         commands:
-          - sed -i 's|@PACKAGE_VERSION@|0.19_pre-22492|' src/XDGData/org.freecadweb.FreeCAD.appdata.xml.in
+          - sed -i 's|@PACKAGE_VERSION@|0.19_pre-22611|' src/XDGData/org.freecadweb.FreeCAD.appdata.xml.in
           - sed -i 's|/usr|/app|g' cMake/FindOpenCasCade.cmake src/Gui/GraphvizView.cpp


### PR DESCRIPTION
In the previous build the Draft workbench generated errors. This is fixed in this new pre-release.