### PR TITLE
Support openscad import properly

### DIFF
--- a/openscad.sh
+++ b/openscad.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+#
+# This wrapper makes a lot of assumptions on how openscad is called
+# from within FreeCAD
+#
+
+BASEDIR="$XDG_CACHE_HOME/tmp"
+
+if test "$1" != "-o"; then
+    exec flatpak-spawn --directory=`pwd` --host flatpak run --filesystem="$BASEDIR" org.openscad.OpenSCAD $*
+else
+    REMOTE_OUT="$BASEDIR/`basename "$2"`"
+    exec flatpak-spawn --directory=`pwd` --host flatpak run --filesystem="$BASEDIR" org.openscad.OpenSCAD -o "$REMOTE_OUT" "$3"
+fi

--- a/org.freecadweb.FreeCAD.yaml
+++ b/org.freecadweb.FreeCAD.yaml
@@ -15,6 +15,8 @@ finish-args:
   - --share=network
   - --filesystem=host # needed to make file saving work
   - --filesystem=xdg-run/gvfs # make GnomeVFS accessible
+  - --talk-name=org.freedesktop.Flatpak # to launch openscad
+  - --env=TMPDIR=/var/tmp
 cleanup:
   - /include
   - /share/aclocal
@@ -586,6 +588,7 @@ modules:
       - -DPYSIDE_INCLUDE_DIR=/app/include/PySide2
       - -DPYSIDE_LIBRARY=pyside2.cpython-38-x86_64-linux-gnu
     post-install:
+      - install -Dm755 ../openscad.sh ${FLATPAK_DEST}/bin/openscad
       - ln -s /app/freecad/bin/FreeCADCmd /app/bin/FreeCADCmd
       - install -D ../FreeCAD.sh /app/bin/FreeCAD
     cleanup:
@@ -601,6 +604,8 @@ modules:
         commit: 783e1346c7a078f5265c3f0c6a927d09a8c1fe70
       - type: patch
         path: patches/freecad-pyside-5.14.patch
+      - type: file
+        path: openscad.sh
       - type: shell
         commands:
           - sed -i 's|@PACKAGE_VERSION@|0.18.4|' src/XDGData/org.freecadweb.FreeCAD.appdata.xml.in

--- a/org.freecadweb.FreeCAD.yaml
+++ b/org.freecadweb.FreeCAD.yaml
@@ -563,6 +563,15 @@ modules:
         url: http://gmsh.info/src/gmsh-4.6.0-source.tgz
         sha256: 0f2c55e50fb6c478ebc8977f6341c223754cbf3493b7b0d683b4395ae9f2ad1c
 
+  - name: python3-ply
+    buildsystem: simple
+    build-commands:
+      - pip3 install --exists-action=i --no-index --find-links="file://${PWD}" --prefix=${FLATPAK_DEST} ply==3.11
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/a3/58/35da89ee790598a0700ea49b2a66594140f44dec458c07e8e3d4979137fc/ply-3.11-py2.py3-none-any.whl
+        sha256: 096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce
+
   - name: FreeCAD
     buildsystem: cmake-ninja
     builddir: true


### PR DESCRIPTION
Closes #30 , Closes #24

You need the openscad flatpak.
It goes .scad -> .csg -> FreeCAD.
So if importing a .scad works, importing a .csg works.