### PR TITLE
Update boost to 1.78 and update links

### DIFF
--- a/org.freecadweb.FreeCAD.yaml
+++ b/org.freecadweb.FreeCAD.yaml
@@ -179,8 +179,8 @@ modules:
       - ./b2 install cxxflags="-I/usr/include/python3.7m" -j $FLATPAK_BUILDER_N_JOBS
     sources:
       - type: archive
-        url: https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2
-        sha256: 2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba
+        url: https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.bz2
+        sha256: 8681f175d4bdb26c52222665793eef08490d7758529330f98d3b29dd0735bccc
 
   - name: coin
     buildsystem: cmake-ninja


### PR DESCRIPTION
Bintray gives a 502 if you try to build it