### PR TITLE
Feature/flatmesh support

### DIFF
--- a/org.freecadweb.FreeCAD.yaml
+++ b/org.freecadweb.FreeCAD.yaml
@@ -179,7 +179,7 @@ modules:
       - ./b2 install cxxflags="-I/usr/include/python3.7m" -j $FLATPAK_BUILDER_N_JOBS
     sources:
       - type: archive
-        url: https://dl.bintray.com/boostorg/release/1.67.0/source/boost_1_67_0.tar.bz2
+        url: https://boostorg.jfrog.io/artifactory/main/release/1.67.0/source/boost_1_67_0.tar.bz2
         sha256: 2684c972994ee57fc5632e03bf044746f6eb45d4920c343937a465fd67a5adba
 
   - name: coin

--- a/org.freecadweb.FreeCAD.yaml
+++ b/org.freecadweb.FreeCAD.yaml
@@ -610,6 +610,21 @@ modules:
   - python3-pyyaml.json
   - python3-Pillow.json
 
+  # pybind11 used by mesh flattening feature
+  - name: pybind11
+    buildsystem: cmake-ninja
+    builddir: true
+    build-options:
+      - --target=pybind11::headers
+    config-opts:
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DPYBIND11_INSTALL=ON
+      - -DPYBIND11_TEST=OFF
+    sources:
+      - type: archive
+        url: https://deb.debian.org/debian/pool/main/p/pybind11/pybind11_2.9.0.orig.tar.gz
+        sha256: 057fb68dafd972bc13afb855f3b0d8cf0fa1a78ef053e815d9af79be7ff567cb
+
   - name: FreeCAD
     buildsystem: cmake-ninja
     builddir: true
@@ -618,6 +633,8 @@ modules:
       - -DCMAKE_INSTALL_PREFIX=/app/freecad
       - -DCMAKE_INSTALL_DATAROOTDIR=/app/share
       - -DCMAKE_PREFIX_PATH=/app
+      - -DFREECAD_USE_PYBIND11=ON
+      - -DBUILD_FLAT_MESH=ON
       - -DBUILD_QT5=ON
       - -DSHIBOKEN_INCLUDE_DIR=/app/include/shiboken2
       - -DPYSIDE_INCLUDE_DIR=/app/include/PySide2
@@ -627,10 +644,14 @@ modules:
           config-opts:
             - -DSHIBOKEN_LIBRARY=shiboken2.cpython-39-x86_64-linux-gnu
             - -DPYSIDE_LIBRARY=pyside2.cpython-39-x86_64-linux-gnu
+            - -DCMAKE_C_FLAGS_INIT=-I/usr/include/x86_64-linux-gnu/python3.9 -I/usr/include/python3.9
+            - -DCMAKE_CXX_FLAGS_INIT=-I/usr/include/x86_64-linux-gnu/python3.9 -I/usr/include/python3.9
         aarch64:
           config-opts:
             - -DSHIBOKEN_LIBRARY=shiboken2.cpython-39-aarch64-linux-gnu
             - -DPYSIDE_LIBRARY=pyside2.cpython-39-aarch64-linux-gnu
+            - -DCMAKE_C_FLAGS_INIT=-I/usr/include/aarch64-linux-gnu/python3.9 -I/usr/include/python3.9
+            - -DCMAKE_CXX_FLAGS_INIT=-I/usr/include/aarch64-linux-gnu/python3.9 -I/usr/include/python3.9
     post-install:
       - install -Dm755 ../openscad.sh ${FLATPAK_DEST}/bin/openscad
       - ln -s /app/freecad/bin/FreeCADCmd /app/bin/FreeCADCmd

--- a/org.freecadweb.FreeCAD.yaml
+++ b/org.freecadweb.FreeCAD.yaml
@@ -610,21 +610,6 @@ modules:
   - python3-pyyaml.json
   - python3-Pillow.json
 
-  # pybind11 used by mesh flattening feature
-  - name: pybind11
-    buildsystem: cmake-ninja
-    builddir: true
-    build-options:
-      - --target=pybind11::headers
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DPYBIND11_INSTALL=ON
-      - -DPYBIND11_TEST=OFF
-    sources:
-      - type: archive
-        url: https://deb.debian.org/debian/pool/main/p/pybind11/pybind11_2.9.0.orig.tar.gz
-        sha256: 057fb68dafd972bc13afb855f3b0d8cf0fa1a78ef053e815d9af79be7ff567cb
-
   - name: FreeCAD
     buildsystem: cmake-ninja
     builddir: true
@@ -633,7 +618,6 @@ modules:
       - -DCMAKE_INSTALL_PREFIX=/app/freecad
       - -DCMAKE_INSTALL_DATAROOTDIR=/app/share
       - -DCMAKE_PREFIX_PATH=/app
-      - -DFREECAD_USE_PYBIND11=ON
       - -DBUILD_FLAT_MESH=ON
       - -DBUILD_QT5=ON
       - -DSHIBOKEN_INCLUDE_DIR=/app/include/shiboken2
@@ -644,14 +628,10 @@ modules:
           config-opts:
             - -DSHIBOKEN_LIBRARY=shiboken2.cpython-39-x86_64-linux-gnu
             - -DPYSIDE_LIBRARY=pyside2.cpython-39-x86_64-linux-gnu
-            - -DCMAKE_C_FLAGS_INIT=-I/usr/include/x86_64-linux-gnu/python3.9 -I/usr/include/python3.9
-            - -DCMAKE_CXX_FLAGS_INIT=-I/usr/include/x86_64-linux-gnu/python3.9 -I/usr/include/python3.9
         aarch64:
           config-opts:
             - -DSHIBOKEN_LIBRARY=shiboken2.cpython-39-aarch64-linux-gnu
             - -DPYSIDE_LIBRARY=pyside2.cpython-39-aarch64-linux-gnu
-            - -DCMAKE_C_FLAGS_INIT=-I/usr/include/aarch64-linux-gnu/python3.9 -I/usr/include/python3.9
-            - -DCMAKE_CXX_FLAGS_INIT=-I/usr/include/aarch64-linux-gnu/python3.9 -I/usr/include/python3.9
     post-install:
       - install -Dm755 ../openscad.sh ${FLATPAK_DEST}/bin/openscad
       - ln -s /app/freecad/bin/FreeCADCmd /app/bin/FreeCADCmd


### PR DESCRIPTION
From the second commit message :

--------

Add support for the `Unwrap Mesh` and `Unwrap Face` features in the Mesh
Workbench.

These features allow to unfold a mesh, as detailled here :
    - https://wiki.freecadweb.org/Mesh_Workbench
    - https://www.youtube.com/watch?v=-KjMZkLfE1A

These features are enabled via the `BUILD_FLAT_MESH` compilation option
(which defaults to `OFF`), and makes use of the `pybind11` library.

This commit also adds the `pybind11` module to the flatpak app.

However, the `FREECAD_USE_PYBIND11` compilation option of FreeCAD enables
some code paths which are requiring the `Python.h` header, but this
header is not available in the flatpak runtime. Due to this reason, the
compilation fails.
Such header is generally found in `python-dev` like packages
(`python-dev` on debian based systems, `python-devel` on fedora based
systems), or directly in the python language installation from sources.

Providing this header to the runtime is necessary, but the python
language installation might not be done in this flatpak application
declaration, but rather in a flatpak extention (e.g. like the
`org.freedesktop.Sdk.Extension.php74` extention which brings the PHP
language installation to the runtime which uses it).


-------


I sent an email to `admins [at] flathub [dot] org` to ask about such python extension, let me know if I should make this request somewhere else.