### PR TITLE
Issue #61 - Use QtWebEngine

### DIFF
--- a/org.freecadweb.FreeCAD.yaml
+++ b/org.freecadweb.FreeCAD.yaml
@@ -1,6 +1,6 @@
 app-id: org.freecadweb.FreeCAD
 default-branch: beta
-base: io.qt.qtwebkit.BaseApp
+base: io.qt.qtwebengine.BaseApp
 base-version: '5.15-21.08'
 runtime: org.kde.Platform
 runtime-version: '5.15-21.08'
@@ -20,6 +20,7 @@ finish-args:
   - --talk-name=org.freedesktop.Flatpak # to launch openscad
   - --env=TMPDIR=/var/tmp
   - --env=SPNAV_SOCKET=/run/spnav.sock
+  - --env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.llvm12
 add-extensions:
@@ -55,6 +56,8 @@ modules:
       - type: archive
         url: https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.15.2-src/pyside-setup-opensource-src-5.15.2.tar.xz
         sha256: b306504b0b8037079a8eab772ee774b9e877a2d84bab2dbefbe4fa6f83941418
+      - type: patch
+        path: patches/pyside-webengine.patch
       - type: shell
         commands:
           - mkdir -p /app/include/qt5tmp && cp -R /usr/include/Qt* /app/include/qt5tmp # https://bugreports.qt.io/browse/PYSIDE-787

--- a/org.freecadweb.FreeCAD.yaml
+++ b/org.freecadweb.FreeCAD.yaml
@@ -60,7 +60,7 @@ modules:
         path: patches/pyside-webengine.patch
       - type: shell
         commands:
-          - mkdir -p /app/include/qt5tmp && cp -R /usr/include/Qt* /app/include/qt5tmp # https://bugreports.qt.io/browse/PYSIDE-787
+          - mkdir -p /app/include/qt5tmp && cp -R /usr/include/Qt* /app/include/Qt* /app/include/qt5tmp # https://bugreports.qt.io/browse/PYSIDE-787
           - sed -i 's|\(--include-paths=\)|\1/app/include/qt5tmp:|' sources/pyside2/cmake/Macros/PySideModules.cmake
 
   - name: swig

--- a/org.freecadweb.FreeCAD.yaml
+++ b/org.freecadweb.FreeCAD.yaml
@@ -54,8 +54,8 @@ modules:
       - /bin
     sources:
       - type: archive
-        url: https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.15.2-src/pyside-setup-opensource-src-5.15.2.tar.xz
-        sha256: b306504b0b8037079a8eab772ee774b9e877a2d84bab2dbefbe4fa6f83941418
+        url: https://download.qt.io/official_releases/QtForPython/pyside2/PySide2-5.15.4-src/pyside-setup-opensource-src-5.15.4.tar.xz
+        sha256: 3c68ed0def4111ef5d0641370306338d277ae8983a77eaf22f223ddd3a14450b
       - type: patch
         path: patches/pyside-webengine.patch
       - type: shell

--- a/patches/pyside-webengine.patch
+++ b/patches/pyside-webengine.patch
@@ -1,0 +1,11 @@
+--- pyside2/sources/cmake_helpers/helpers.cmake-orig	2022-03-29 12:46:50.510984688 -0400
++++ pyside2/sources/cmake_helpers/helpers.cmake	2022-03-29 12:48:11.879534516 -0400
+@@ -168,7 +168,7 @@
+     # If the module was found, and also the module path is the same as the
+     # Qt5Core base path, we will generate the list with the modules to be installed
+     set(looked_in_message ". Looked in: ${${_name_dir}}")
+-    if("${${_name_found}}" AND (("${found_basepath}" GREATER "0") OR ("${found_basepath}" EQUAL "0")))
++    if("${${_name_found}}") #AND (("${found_basepath}" GREATER "0") OR ("${found_basepath}" EQUAL "0")))
+         message(STATUS "${module_state} module ${name} found (${ARGN})${looked_in_message}")
+         # record the shortnames for the tests
+         list(APPEND all_module_shortnames ${shortname})


### PR DESCRIPTION
@aleixpol this is the build where pyside "skip" QtWebEngine because it's not in the same prefix. It's a deliberate check in the cmakefile.

Build will be successfull but the resulting package will be failing to launch.

Closes #61 